### PR TITLE
Add codiceIPA key to publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -28,6 +28,8 @@ description:
     shortDescription: Notizia esterna
 developmentStatus: stable
 it:
+  riuso:
+    codiceIPA: r_emiro
   conforme:
     gdpr: true
     lineeGuidaDesign: false


### PR DESCRIPTION
This PR:

*    adds the codiceIPA key to the publiccode.yml file.

Please note that there is still a problem with the `longDescription` field since it's too short (215) where the minimum is 500 chars.
Thanks @nzambello 